### PR TITLE
Make health score friendly name generic

### DIFF
--- a/EXERCISE_SDL3_Building Asset Trees.ipynb
+++ b/EXERCISE_SDL3_Building Asset Trees.ipynb
@@ -254,7 +254,7 @@
    "outputs": [],
    "source": [
     "my_csv_tree.insert(children=search_results,\n",
-    "               friendly_name='CT1 Health Score',\n",
+    "               friendly_name='Health Score',\n",
     "               parent='Cooling Tower 1')\n",
     "\n",
     "my_csv_tree.visualize()"
@@ -278,7 +278,7 @@
     "search_results = spy.search(query = {'Name': 'CT2 Health Score'})\n",
     "\n",
     "my_csv_tree.insert(children=search_results,\n",
-    "               friendly_name='CT2 Health Score',\n",
+    "               friendly_name='Health Score',\n",
     "               parent='Cooling Tower 2')\n",
     "\n",
     "my_csv_tree.visualize()"
@@ -357,7 +357,7 @@
     "#Step 5: Insert a Signal\n",
     "search_results = spy.search(query = {'Name': 'CT1 Health Score'})\n",
     "my_csv_tree.insert(children=search_results,\n",
-    "               friendly_name='CT1 Health Score',\n",
+    "               friendly_name='Health Score',\n",
     "               parent='Cooling Tower 1')\n",
     "\n",
     "#Step 6: \n",


### PR DESCRIPTION
Allow health score signals to swap across cooling towers by making their friendly name generic.