### PR TITLE
fix compatibility typo

### DIFF
--- a/EXERCISE_SDL1_Exploring Data Using Data Lab.ipynb
+++ b/EXERCISE_SDL1_Exploring Data Using Data Lab.ipynb
@@ -32,7 +32,7 @@
     "import pandas as pd\n",
     "\n",
     "# Set the compatibility option so that you maximize the chance that SPy will remain compatible with your notebook/script\n",
-    "spy.options.compatbility = 188"
+    "spy.options.compatibility = 188"
    ]
   },
   {


### PR DESCRIPTION
Simple typo fix when setting compatibility in exercise 1. Logged SPy feature request to more safely set compatibility.